### PR TITLE
Loop fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,12 +16,12 @@ Here's an example of usage with
 `aiohttp <https://github.com/KeepSafe/aiohttp>`_ framework:
 
 .. code-block:: python
-    
+
     app = aiohttp.web.Application()
-    aioreloader.start(app.loop)
+    aioreloader.start()
     aiohttp.web.run_app(app)
-    
+
 Requirements
 ------------
 
-Python - at least 3.4
+Python - at least 3.3

--- a/aioreloader.py
+++ b/aioreloader.py
@@ -20,14 +20,14 @@ def start(loop: _abstract_loop = None, interval: float = 0.5) -> None:
     """
     if loop is None:
         loop = asyncio.get_event_loop()
-        
+
     global _started
     if _started:
         return
     _started = True
 
     modify_times = {}
-    _call_periodically(loop, interval, _check_all, modify_times)
+    return _call_periodically(loop, interval, _check_all, modify_times)
 
 
 def watch(path: str) -> None:
@@ -43,7 +43,7 @@ def _call_periodically(loop: _abstract_loop, interval, callback, *args):
         while True:
             yield from asyncio.sleep(interval, loop=loop)
             callback(*args)
-    return loop.create_task(wrap())
+    return asyncio.ensure_future(wrap(), loop=loop)
 
 
 def _check_all(modify_times):
@@ -74,7 +74,7 @@ def _reload():
     _reload_attempted = True
     if sys.platform == 'win32':
         subprocess.Popen([sys.executable] + sys.argv)
-        sys.exit(0)
+        sys.exit(os.EX_OK)
     else:
         try:
             os.execv(sys.executable, [sys.executable] + sys.argv)
@@ -82,6 +82,6 @@ def _reload():
             os.spawnv(
                 os.P_NOWAIT,
                 sys.executable,
-                [sys.executable] + sys.argv
+                [sys.executable] + sys.argv,
             )
-            os._exit(0)
+            os._exit(os.EX_OK)

--- a/aioreloader.py
+++ b/aioreloader.py
@@ -11,13 +11,16 @@ _reload_attempted = False
 _files = set()
 
 
-def start(loop: _abstract_loop, interval: float = 0.5) -> None:
+def start(loop: _abstract_loop = None, interval: float = 0.5) -> None:
     """
     Start the reloader: create the task which is watching
     loaded modules and manually added files via ``watch()``
     and reloading the process in case of modification, and
     attach this task to the loop.
     """
+    if loop is None:
+        loop = asyncio.get_event_loop()
+        
     global _started
     if _started:
         return
@@ -38,7 +41,7 @@ def _call_periodically(loop: _abstract_loop, interval, callback, *args):
     @asyncio.coroutine
     def wrap():
         while True:
-            yield from asyncio.sleep(interval)
+            yield from asyncio.sleep(interval, loop=loop)
             callback(*args)
     return loop.create_task(wrap())
 

--- a/aioreloader.py
+++ b/aioreloader.py
@@ -4,6 +4,11 @@ import subprocess
 import asyncio
 from types import ModuleType
 
+try:
+    ensure_future = asyncio.ensure_future
+except AttributeError:
+    ensure_future = getattr(asyncio, 'async')
+
 _abstract_loop = asyncio.AbstractEventLoop
 
 _started = False
@@ -43,7 +48,7 @@ def _call_periodically(loop: _abstract_loop, interval, callback, *args):
         while True:
             yield from asyncio.sleep(interval, loop=loop)
             callback(*args)
-    return asyncio.ensure_future(wrap(), loop=loop)
+    return ensure_future(wrap(), loop=loop)
 
 
 def _check_all(modify_times):

--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,7 @@ setup(
     author_email='andriy.maletsky@gmail.com',
     license='MIT',
     py_modules=['aioreloader'],
+    extras_require={
+        ':python_version=="3.3"': ['asyncio'],
+    },
 )


### PR DESCRIPTION
1) There is no need to pass explicit loop, it can be found in `MainThread`

2) swap `loop.create_task` to `asyncio.ensure_future` (actually same, but works on any Python3.3+ version)

3) return future for `_call_periodically`, to have ability to cancel it

4) fix loop sleep missed statement 

